### PR TITLE
[Phase 3] feat: app session and role-aware approvals

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { SESSION_COOKIE_NAME } from "@/lib/auth-config";
+
+const PUBLIC_PATHS = new Set(["/login", "/api/events", "/api/auth/session"]);
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const sessionRole = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+
+  if (pathname === "/login") {
+    if (sessionRole) {
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+
+    return NextResponse.next();
+  }
+
+  if (PUBLIC_PATHS.has(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (!sessionRole) {
+    const loginUrl = new URL("/login", request.url);
+    if (pathname !== "/") {
+      loginUrl.searchParams.set("next", pathname);
+    }
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { SESSION_COOKIE_NAME } from "@/lib/auth-config";
+import { getSessionUserByRole, isValidUserRole } from "@/lib/auth";
+
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as { role?: string } | null;
+  const role = body?.role;
+
+  if (!role || !isValidUserRole(role)) {
+    return NextResponse.json({ error: "Invalid role selection" }, { status: 400 });
+  }
+
+  const sessionUser = getSessionUserByRole(role);
+  const response = NextResponse.json({ ok: true, user: sessionUser });
+
+  response.cookies.set(SESSION_COOKIE_NAME, role, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  return response;
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(SESSION_COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+
+  return response;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,24 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Shell from "@/components/Shell";
+import { getSessionUser } from "@/lib/auth";
 
 export const metadata: Metadata = {
   title: "AgentOps CRM",
   description: "Unified dashboard for autonomous agents",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const sessionUser = await getSessionUser();
+
   return (
     <html lang="en">
       <body className="antialiased">
-        <Shell>{children}</Shell>
+        <Shell sessionUser={sessionUser}>{children}</Shell>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { appUsers } from "@/lib/data";
+import type { UserRole } from "@/lib/types";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [selectedRole, setSelectedRole] = useState<UserRole | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const nextPath = useMemo(() => searchParams.get("next") || "/", [searchParams]);
+
+  async function handleSignIn(role: UserRole) {
+    setSelectedRole(role);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/auth/session", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ role }),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error ?? "Unable to start a session.");
+      }
+
+      router.push(nextPath);
+      router.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to start a session.";
+      setError(message);
+      setSelectedRole(null);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-10rem)] max-w-5xl items-center justify-center">
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+          <span className="inline-flex rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
+            Phase 3 Access Control
+          </span>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-900">
+            Sign in to AgentOps CRM
+          </h1>
+          <p className="mt-4 max-w-xl text-sm leading-6 text-slate-600">
+            This slice introduces app-level session gating and role-aware approvals without changing deployment,
+            secrets, or infrastructure. Choose the role you want to simulate for this session.
+          </p>
+
+          {error ? (
+            <p className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+              {error}
+            </p>
+          ) : null}
+        </section>
+
+        <section className="space-y-4 rounded-3xl border border-slate-200 bg-slate-950 p-6 text-white shadow-xl">
+          {appUsers.map((user) => {
+            const isLoading = selectedRole === user.role;
+
+            return (
+              <button
+                key={user.id}
+                type="button"
+                onClick={() => handleSignIn(user.role)}
+                disabled={selectedRole !== null}
+                className="w-full rounded-2xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-cyan-400/60 hover:bg-cyan-400/10 disabled:cursor-wait disabled:opacity-70"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.16em] text-cyan-300">{user.role}</p>
+                    <h2 className="mt-2 text-2xl font-semibold">{user.name}</h2>
+                    <p className="mt-1 text-sm text-slate-300">{user.title}</p>
+                  </div>
+                  <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                    {isLoading ? "Signing in" : "Use role"}
+                  </span>
+                </div>
+                <p className="mt-4 text-sm leading-6 text-slate-300">{user.description}</p>
+              </button>
+            );
+          })}
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,17 +3,19 @@ import { StatsCard } from "@/components/StatsCard";
 import AgentRunsTable from "@/components/AgentRunsTable";
 import ApprovalCenter from "@/components/ApprovalCenter";
 import { ActivityTimeline } from "@/components/ActivityTimeline";
+import { canManageApprovals, getSessionUser } from "@/lib/auth";
 import { approvalQueue } from "@/lib/data";
 import { getLiveIssues, getLivePullRequests } from "@/lib/github";
 import { getAgentRuns, getActivityTimeline } from "@/lib/services";
 
 export default async function Home() {
   const repo = "saij3b/agentops-crm";
-  const [runs, timeline, livePRs, liveIssues] = await Promise.all([
+  const [runs, timeline, livePRs, liveIssues, sessionUser] = await Promise.all([
     getAgentRuns(),
     getActivityTimeline(),
     getLivePullRequests(repo),
     getLiveIssues(repo),
+    getSessionUser(),
   ]);
 
   const hasLive = livePRs.length > 0 || liveIssues.length > 0;
@@ -83,7 +85,11 @@ export default async function Home() {
 
           <section>
             <h2 className="text-xl font-semibold mb-4">Pending Approvals</h2>
-            <ApprovalCenter initialItems={approvalQueue} />
+            <ApprovalCenter
+              initialItems={approvalQueue}
+              canManageApprovals={canManageApprovals(sessionUser?.role ?? null)}
+              roleLabel={sessionUser?.role}
+            />
           </section>
         </div>
 

--- a/src/components/ApprovalCenter.tsx
+++ b/src/components/ApprovalCenter.tsx
@@ -6,9 +6,15 @@ import StatusBadge from './StatusBadge';
 
 interface ApprovalCenterProps {
   initialItems: ApprovalItem[];
+  canManageApprovals: boolean;
+  roleLabel?: string;
 }
 
-const ApprovalCenter: React.FC<ApprovalCenterProps> = ({ initialItems }) => {
+const ApprovalCenter: React.FC<ApprovalCenterProps> = ({
+  initialItems,
+  canManageApprovals,
+  roleLabel,
+}) => {
   const [items, setItems] = useState<ApprovalItem[]>(initialItems);
 
   const handleAction = (id: string, action: 'approve' | 'reject') => {
@@ -32,6 +38,11 @@ const ApprovalCenter: React.FC<ApprovalCenterProps> = ({ initialItems }) => {
           <p className="text-sm text-gray-500 dark:text-zinc-400">No pending approvals.</p>
         ) : (
           <div className="grid gap-4">
+            {!canManageApprovals ? (
+              <p className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+                {roleLabel ?? 'Viewer'} access is read-only. Approval actions are limited to reviewer and admin roles.
+              </p>
+            ) : null}
             {pendingItems.map((item) => (
               <div
                 key={item.id}
@@ -49,12 +60,14 @@ const ApprovalCenter: React.FC<ApprovalCenterProps> = ({ initialItems }) => {
                 <div className="flex gap-2">
                   <button
                     onClick={() => handleAction(item.id, 'reject')}
+                    disabled={!canManageApprovals}
                     className="px-3 py-1 text-sm font-medium text-red-600 border border-red-200 rounded hover:bg-red-50 dark:text-red-400 dark:border-red-900/50 dark:hover:bg-red-900/20 transition-colors"
                   >
                     Reject
                   </button>
                   <button
                     onClick={() => handleAction(item.id, 'approve')}
+                    disabled={!canManageApprovals}
                     className="px-3 py-1 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 transition-colors"
                   >
                     Approve

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import React from "react";
+import Link from "next/link";
+import type { SessionUser } from "@/lib/types";
 import { useWebSockets } from "@/hooks/useWebSockets";
 
-export default function Navigation() {
+interface NavigationProps {
+  sessionUser: SessionUser | null;
+  onLogout: () => void | Promise<void>;
+}
+
+export default function Navigation({ sessionUser, onLogout }: NavigationProps) {
   const { status } = useWebSockets();
 
   return (
@@ -11,24 +17,55 @@ export default function Navigation() {
       <div className="flex items-center gap-4">
         <h1 className="text-lg font-semibold text-slate-800 dark:text-white">AgentOps CRM</h1>
         <div className="flex items-center gap-2 px-3 py-1 bg-slate-50 rounded-full dark:bg-zinc-800">
-          <div className={`w-2 h-2 rounded-full ${
-            status === "connected" ? "bg-green-500 animate-pulse" : 
-            status === "connecting" ? "bg-yellow-500" : "bg-red-500"
-          }`} />
+          <div
+            className={`w-2 h-2 rounded-full ${
+              status === "connected"
+                ? "bg-green-500 animate-pulse"
+                : status === "connecting"
+                  ? "bg-yellow-500"
+                  : "bg-red-500"
+            }`}
+          />
           <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-zinc-400">
             {status === "connected" ? "Real-time: Active" : `System: ${status}`}
           </span>
         </div>
       </div>
-      <div className="flex items-center gap-4">
-        <button className="p-2 text-slate-400 hover:text-slate-600 dark:hover:text-white">
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-          </svg>
-        </button>
-        <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-bold">
-          SJ
+
+      <div className="flex items-center gap-3">
+        <div className="hidden sm:flex gap-4 text-sm text-slate-500 dark:text-zinc-400">
+          <Link href="/clients" className="hover:text-slate-900 dark:hover:text-white">
+            Clients
+          </Link>
+          <Link href="/projects" className="hover:text-slate-900 dark:hover:text-white">
+            Projects
+          </Link>
         </div>
+
+        {sessionUser ? (
+          <>
+            <div className="hidden sm:flex flex-col items-end">
+              <span className="text-sm font-semibold text-slate-900 dark:text-white">{sessionUser.name}</span>
+              <span className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-zinc-400">
+                {sessionUser.role}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => void onLogout()}
+              className="rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-slate-600 transition hover:border-slate-300 hover:text-slate-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:text-white"
+            >
+              Sign out
+            </button>
+          </>
+        ) : (
+          <Link
+            href="/login"
+            className="rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-slate-600 transition hover:border-slate-300 hover:text-slate-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:text-white"
+          >
+            Sign in
+          </Link>
+        )}
       </div>
     </header>
   );

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -3,15 +3,28 @@
 import React, { useState } from "react";
 import { Sidebar } from "./Sidebar";
 import Navigation from "./Navigation";
+import type { SessionUser } from "@/lib/types";
 
-export default function Shell({ children }: { children: React.ReactNode }) {
+interface ShellProps {
+  children: React.ReactNode;
+  sessionUser: SessionUser | null;
+}
+
+export default function Shell({ children, sessionUser }: ShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  async function handleLogout() {
+    await fetch("/api/auth/session", {
+      method: "DELETE",
+    });
+    window.location.href = "/login";
+  }
 
   return (
     <div className="flex h-screen bg-slate-50 text-slate-900">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       <div className="flex-1 flex flex-col overflow-hidden">
-        <Navigation />
+        <Navigation sessionUser={sessionUser} onLogout={handleLogout} />
         <main className="flex-1 overflow-y-auto p-6">
           {children}
         </main>

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,0 +1,2 @@
+export const SESSION_COOKIE_NAME = "agentops_role";
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+
+import { SESSION_COOKIE_NAME } from "./auth-config";
+import { appUsers } from "./data";
+import type { SessionUser, UserRole } from "./types";
+
+const userByRole = new Map<UserRole, SessionUser>(
+  appUsers.map((user) => [user.role, user]),
+);
+
+export function isValidUserRole(role: string): role is UserRole {
+  return userByRole.has(role as UserRole);
+}
+
+export function getSessionUserByRole(role?: string | null): SessionUser | null {
+  if (!role || !isValidUserRole(role)) {
+    return null;
+  }
+
+  return userByRole.get(role) ?? null;
+}
+
+export async function getSessionUser(): Promise<SessionUser | null> {
+  const cookieStore = await cookies();
+  return getSessionUserByRole(cookieStore.get(SESSION_COOKIE_NAME)?.value);
+}
+
+export function canManageApprovals(role?: UserRole | null): boolean {
+  return role === "admin" || role === "reviewer";
+}
+

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { Client, Project, AgentRun, ApprovalItem, ActivityEvent, Agent } from './types';
+import { Client, Project, AgentRun, ApprovalItem, ActivityEvent, Agent, SessionUser } from './types';
 
 export const clients: Client[] = [
   { id: 'c1', name: 'Alice Smith', company: 'TechCorp', status: 'active', priority: 'high' },
@@ -81,4 +81,28 @@ export const navItems = [
   { name: 'Clients', href: '/clients', icon: 'Users' },
   { name: 'Projects', href: '/projects', icon: 'FolderKanban' },
   { name: 'Orchestration', href: '/orchestration', icon: 'Radio' },
+];
+
+export const appUsers: SessionUser[] = [
+  {
+    id: 'u-admin',
+    name: 'Ops Admin',
+    title: 'Workspace Owner',
+    role: 'admin',
+    description: 'Full access to dashboards, approvals, and future admin-only controls.',
+  },
+  {
+    id: 'u-reviewer',
+    name: 'Codex Reviewer',
+    title: 'Staff Reviewer',
+    role: 'reviewer',
+    description: 'Can inspect the CRM and process approval tasks without admin-only ownership.',
+  },
+  {
+    id: 'u-viewer',
+    name: 'Stakeholder Viewer',
+    title: 'Read-only Observer',
+    role: 'viewer',
+    description: 'Can browse the CRM safely, but cannot approve or reject sensitive actions.',
+  },
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,16 @@ export interface ApprovalItem {
   status: Status;
 }
 
+export type UserRole = 'admin' | 'reviewer' | 'viewer';
+
+export interface SessionUser {
+  id: string;
+  name: string;
+  title: string;
+  role: UserRole;
+  description: string;
+}
+
 export type ActivityType =
   | 'issue_created'
   | 'agent_assigned'


### PR DESCRIPTION
## Phase 3 Slice 2
Implements the first safe auth-and-roles slice on top of live activity ingestion.

### Changes
- Adds app-level session cookies and a role selection login flow.
- Protects dashboard routes with middleware while leaving ingestion API access intact.
- Adds reviewer/admin approval gating and read-only viewer behavior.
- Surfaces the current signed-in role in the shell.

### Safety
- No deploy or merge automation added.
- No workflow, infra, billing, or secret changes.
- Keeps the existing data layer and ingestion flow intact.

Closes #25